### PR TITLE
spigotdownloader multithreaded + misc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /target/
 /data/
+#general ide
+/build/
+#IntelliJ IDEA
+/.idea/
+/*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>Optic_Fusion1</groupId>
     <artifactId>AntiMalwareToolKit</artifactId>
     <version>1.2</version>
     <packaging>jar</packaging>
     <build>
+        <defaultGoal>clean package</defaultGoal>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -21,7 +23,7 @@
                     <finalName>${project.artifactId}</finalName>
                     <transformers>
                         <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>optic_fusion1.antimalwaretoolkit.Main</mainClass>
                         </transformer>
                     </transformers>
@@ -33,14 +35,14 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <filters> 
+                            <filters>
                                 <filter>
                                     <artifact>com.sun:tools</artifact>
                                     <includes>
                                         <include>sun/tools/attach/**/*</include>
                                         <include>com/sun/tools/attach/**/*</include>
                                     </includes>
-                                </filter>                    
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>
@@ -61,25 +63,21 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.9</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.8.0</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>20.1.0</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.28</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -110,25 +108,22 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>30.1-jre</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
-            <type>jar</type>
         </dependency>
         <dependency>
-			<groupId>org.xerial</groupId>
-			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.34.0</version>
-		</dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.34.0</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/Main.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/Main.java
@@ -1,37 +1,27 @@
 package optic_fusion1.antimalwaretoolkit;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Scanner;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import optic_fusion1.antimalwaretoolkit.database.Database;
 import optic_fusion1.antimalwaretoolkit.tool.Tool;
-import optic_fusion1.antimalwaretoolkit.tool.impl.ChangeAccess;
-import optic_fusion1.antimalwaretoolkit.tool.impl.Cleanup;
-import optic_fusion1.antimalwaretoolkit.tool.impl.CleanupInvalidFiles;
-import optic_fusion1.antimalwaretoolkit.tool.impl.DatabaseMigration;
-import optic_fusion1.antimalwaretoolkit.tool.impl.ListFiles;
-import optic_fusion1.antimalwaretoolkit.tool.impl.MethodNamePrinter;
-import optic_fusion1.antimalwaretoolkit.tool.impl.PlayerPrinter;
-import optic_fusion1.antimalwaretoolkit.tool.impl.PluginAnalyzer;
-import optic_fusion1.antimalwaretoolkit.tool.impl.SortJars;
-import optic_fusion1.antimalwaretoolkit.tool.impl.SpigotPluginDownloader;
-import optic_fusion1.antimalwaretoolkit.tool.impl.StringPrinter;
-import optic_fusion1.antimalwaretoolkit.tool.impl.UpdateDatabase;
-import optic_fusion1.faith.util.shellparser.ParseException;
-import optic_fusion1.faith.util.shellparser.ShellParser;
+import optic_fusion1.antimalwaretoolkit.tool.impl.*;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ParseException;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ShellParser;
 
 public class Main {
+  
+  private static final SimpleDateFormat formatter = new SimpleDateFormat("HH:mm:ss");
 
-  private HashMap<String, Tool> tools = new HashMap<>();
-  private boolean isRunning;
-  private Scanner scanner = new Scanner(System.in);
-  public static final Database DATABASE = new Database();
+  private final HashMap<String, Tool> tools = new HashMap<>();
+  public static Database DATABASE;
 
   public static void main(String[] args) {
+    System.out.println("Starting...");
+    DATABASE = new Database();
     new Main().main();
   }
 
-  private void addTools() {
+  private Main() {
     tools.put("methodnameprinter", new MethodNamePrinter());
     tools.put("changeaccess", new ChangeAccess());
     tools.put("stringprinter", new StringPrinter());
@@ -47,18 +37,31 @@ public class Main {
   }
 
   private void main() {
-    isRunning = true;
-    addTools();
+    Scanner scanner = new Scanner(System.in);
     System.out.println("Finished loading, run a tool");
+    boolean isRunning = true;
     while (isRunning) {
+      System.out.print("> ");
       try {
         List<String> args = ShellParser.parseString(scanner.nextLine());
         if (args.isEmpty()) {
+          System.out.println();
           continue;
         }
-        Tool tool = tools.get(args.get(0));
+        String toolName = args.get(0).toLowerCase(Locale.ROOT);
+
+        if ("?".equals(toolName)) {
+          tools.forEach((s, tool) -> System.out.println(s + " - " + tool.getDescription()));
+          continue;
+        }
+        if ("stop".equals(toolName)) {
+          isRunning = false;
+          continue;
+        }
+
+        Tool tool = tools.get(toolName);
         if (tool == null) {
-          System.out.println(args.get(0) + " is not a valid tool");
+          System.out.println(toolName + " is not a valid tool");
           continue;
         }
         if (args.size() == 2 && args.get(1).equals("?")) {
@@ -71,6 +74,11 @@ public class Main {
         ex.printStackTrace();
       }
     }
+    System.out.println("Goodbye");
   }
 
+  public static void log(String s) {
+    Date date = new Date();
+    System.out.println("[" + formatter.format(date) + "] [" + Thread.currentThread().getName() + "] " + s);
+  }
 }

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/database/Database.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/database/Database.java
@@ -25,6 +25,7 @@ public class Database {
       try {
         Files.copy(new URL(DATABASE_URL).openStream(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
       } catch (IOException e) {
+        e.printStackTrace();
         Files.copy(Database.class.getResource("/database.db").openStream(), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
       }
       connection = DriverManager.getConnection("jdbc:sqlite:" + tempFile.toURI());

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/SpigotPluginDownloader.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/SpigotPluginDownloader.java
@@ -1,86 +1,128 @@
 package optic_fusion1.antimalwaretoolkit.tool.impl;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import optic_fusion1.antimalwaretoolkit.tool.Tool;
 import org.apache.commons.io.IOUtils;
 
+import static optic_fusion1.antimalwaretoolkit.Main.log;
+
 public class SpigotPluginDownloader extends Tool {
+  
+  private static final int threadCount = Integer.getInteger("downloader.threadcount", 4);
 
   @Override
   public void run(List<String> args) {
     int startingPage = 0;
-    String url = "https://api.spiget.org/v2/resources?size=10&page=";
-    if (args.size() == 1) {
+    int pageCount = 10;
+    String url = "https://api.spiget.org/v2/resources/free?size=10&page=";
+    if (args.size() >= 1) {
       if (args.get(0).equalsIgnoreCase("latest")) {
-        url = "https://api.spiget.org/v2/resources/free?sort=-updateDate&fields=file,name,version&page=";
+        url = "https://api.spiget.org/v2/resources/free?size=10&sort=-updateDate&fields=file,name,version,updateDate,releaseDate&page=";
+        if (args.size() >= 2) {
+          startingPage = Integer.parseInt(args.get(1));
+          if (args.size() >= 3) {
+            pageCount = Integer.parseInt(args.get(2));
+          }
+        }
       } else {
         startingPage = Integer.parseInt(args.get(0));
       }
     }
-    System.out.println("Starting downloader");
-    for (int page = startingPage; page < Integer.MAX_VALUE; page++) {
-      System.out.println("Downloading a new spiget page");
-      boolean success = downloadPage(url, page);
-      if (!success) {
-        break;
+    File dlFolder = new File("data/plugins");
+    dlFolder.mkdirs();
+    File oldFolder = new File("data/old");
+    oldFolder.mkdirs();
+    Multimap<String, String> files = HashMultimap.create(1000, 1);
+    for (String fileName : dlFolder.list()) {
+      String[] split = fileName.split("_lastUpdate");
+      if (split.length != 2) {
+        log("Unknown file " + fileName + ", ignoring...");
+        continue;
       }
+      files.put(split[0], split[1]);
     }
-
-    File[] files = new File("data/plugins").listFiles();
-    for (File file : files) {
-      BufferedReader br = null;
+    log("Found " + files.size() + " existing files, " + files.keySet().size() + " distinct plugins");
+    log("Starting downloader");
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    int maxPage = startingPage + pageCount;
+    for (int page = startingPage; page < maxPage; page++) {
+      log("Scheduling spiget page " + page);
+      String urlFinal = url;
+      int pageFinal = page;
+      executor.submit(() -> {
+        log("Downloading spiget page " + pageFinal);
+        downloadPage(dlFolder, oldFolder, urlFinal, pageFinal, files);
+      });
+    }
+    executor.shutdown();
+    while (!executor.isTerminated()) {
       try {
-        br = new BufferedReader(new FileReader(file.toString()));
-        if (br.readLine() == null) {
-          file.delete();
+        if (executor.awaitTermination(1, TimeUnit.MINUTES)) {
+          if (executor.isTerminated()) {
+            break;
+          }
         }
-      } catch (FileNotFoundException ex) {
-        ex.printStackTrace();
-      } catch (IOException ex) {
-        ex.printStackTrace();
-      } finally {
-        try {
-          br.close();
-        } catch (IOException ex) {
-          ex.printStackTrace();
-        }
+      } catch (InterruptedException e) {
+        e.printStackTrace();
       }
     }
-
-    System.out.println("Done");
+    log("Done, downloaded spiget pages " + startingPage + " to " + maxPage);
   }
 
-  private boolean downloadPage(String url, int currentPage) {
-    String urlString = url + currentPage;
-    System.out.println("Downloading the page: " + urlString);
+  private boolean downloadPage(File dlFolder, File oldFolder, String baseUrl, int currentPage, Multimap<String, String> existing) {
+    String urlString = baseUrl + currentPage;
+    log("Downloading the page: " + urlString);
     String jsonString = "";
     try {
-      jsonString = IOUtils.toString(new URL(urlString), "UTF-8");
+      jsonString = downloadToString(urlString);
     } catch (IOException ex) {
       Logger.getLogger(SpigotPluginDownloader.class.getName()).log(Level.SEVERE, null, ex);
     }
     if (jsonString.isEmpty() || jsonString.equalsIgnoreCase("[]")) {
-      System.out.println("Max page reached");
+      log("Max page reached");
       return false;
     }
     for (JsonElement element : JsonParser.parseString(jsonString).getAsJsonArray()) {
       JsonObject jsonObject = element.getAsJsonObject();
       if (jsonObject == null) {
-        System.out.println("Found a null plugin");
+        log("Found a null plugin");
         continue;
       }
       JsonObject pluginInformation = jsonObject.getAsJsonObject();
       JsonObject pluginFileInformation = pluginInformation.getAsJsonObject("file");
+      
       String fileType = pluginFileInformation == null ? ".jar" : pluginFileInformation.get("type").getAsString();
-      if (fileType.equals("external") || fileType.equals("skript") || fileType.equals("sk")) {
+      
+      String id = pluginInformation.get("id").getAsString().replaceAll("\\.", "");
+      String name = pluginInformation.get("name").getAsString();
+      
+      if (fileType.equals("external")) {
+        log("Skipping external file: id: " + id + " name: " + name);
+        continue;
+      } else if (fileType.equals(".skript") || fileType.equals(".sk")) {
+        log("Skipping skript id: " + id + " name: " + name);
         continue;
       }
       double fileSize = 0;
@@ -92,40 +134,94 @@ public class SpigotPluginDownloader extends Tool {
       if (fileSize == 0) {
         continue;
       }
-      String id = pluginInformation.get("id").getAsString().replaceAll("\\.", "");
-      String name = pluginInformation.get("name").getAsString();
-      System.out.println("Downloading " + name + "(" + id + ")");
-      File output = new File("data/plugins/" + name.replaceAll("[^a-zA-Z]", "") + "(" + id + ")" + fileType);
-      if (!output.exists()) {
-        output.getParentFile().mkdirs();
-        try {
-          output.createNewFile();
-        } catch (IOException ex) {
-          continue;
+      long updateDate = pluginInformation.get("updateDate").getAsLong();
+      long releaseDate = pluginInformation.get("releaseDate").getAsLong();
+      String lastUpdateStr = "_lastUpdate(" + updateDate + ")";
+      log("Downloading " + name + "_id(" + id + ")" + lastUpdateStr);
+      String fileNamePart1 = name.replaceAll("[^a-zA-Z0-9]", "") + "_id(" + id + ")";
+      String fileNamePart2 = lastUpdateStr + fileType;
+      Collection<String> exist = existing.get(fileNamePart1);
+      if (!exist.isEmpty()) {
+        for (String s : exist) {
+          if (!fileNamePart2.equals(s)) {
+            try {
+              Files.move(
+                  new File(dlFolder, fileNamePart1 + s).toPath(),
+                  new File(oldFolder, fileNamePart1 + s).toPath(),
+                  StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.COPY_ATTRIBUTES,
+                  StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+              e.printStackTrace();
+            }
+          }
         }
       }
-      download(id, output);
-      System.out.println("Downloaded " + name + "(" + id + ") File Type: " + fileType + " Output: " + output);
+
+      String fileName = fileNamePart1 + fileNamePart2;
+      File output = new File(dlFolder, fileName);
+      if (!output.exists()) {
+        download(id, output, releaseDate, updateDate);
+        log("Downloaded " + name + " id: " + id + ", File Type: " + fileType);
+        log("  Output: " + fileName);
+      } else {
+        log("No new update for " + fileName);
+      }
     }
     return true;
   }
 
-  private void download(String resourceID, File output) {
+  private void download(String resourceID, File output, long releaseDate, long updateDate) {
     try {
-      URL url = new URL("http://aqua.api.spiget.org/v2/resources/" + resourceID + "/download");
+      URL url = new URL("https://api.spiget.org/v2/resources/" + resourceID + "/download");
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      conn.setRequestProperty("User-Agent", "Optic_Fusion1 Antimalware");
+      conn.setInstanceFollowRedirects(true);
+      conn.setRequestProperty("User-Agent", "Optic_Fusion1 AntimalwareToolkit");
       conn.setRequestMethod("GET");
-
-      try (InputStream in = conn.getInputStream(); FileOutputStream out = new FileOutputStream(output)) {
-        byte[] b = new byte[1024];
-        int n = in.read(b);
-        while (n != -1) {
-          out.write(b, 0, n);
-          n = in.read(b);
+      int responseCode = conn.getResponseCode();
+      if (responseCode == 307) {
+        String location = conn.getHeaderField("Location");
+        if (location == null) {
+          log("Redirect without location for url: " + url.getPath());
+        } else {
+          log("Redirected to : " + location);
+          url = new URL(location);
+          conn = (HttpURLConnection) url.openConnection();
+          conn.setInstanceFollowRedirects(true);
+          conn.setRequestProperty("User-Agent", "Optic_Fusion1 AntimalwareToolkit");
+          conn.setRequestMethod("GET");
         }
+      } else if (responseCode != 200) {
+        log("Response code was " + responseCode + " for resource " + resourceID);
       }
-    } catch (IOException e) {
+
+      InputStream inputStream = conn.getInputStream();
+      FileOutputStream fileOutputStream = new FileOutputStream(output);
+      IOUtils.copy(inputStream, fileOutputStream);
+      try {
+        IOUtils.close(fileOutputStream);
+      } catch (Exception ex) {
+        System.err.println("Close error 1 for " + resourceID);
+        ex.printStackTrace();
+      }
+      
+      Path outputPath = output.toPath();
+      Files.setAttribute(outputPath, "creationTime", FileTime.from(releaseDate, TimeUnit.SECONDS));
+      Files.setLastModifiedTime(outputPath, FileTime.from(updateDate, TimeUnit.SECONDS));
+      try {
+        IOUtils.close(inputStream);
+      } catch (Exception ex) {
+        System.err.println("Close error 2 for " + resourceID);
+        ex.printStackTrace();
+      }
+      try {
+        IOUtils.close(conn);
+      } catch (Exception ex) {
+        System.err.println("Close error 3 for " + resourceID);
+        ex.printStackTrace();
+      }
+    } catch (Exception ex) {
+      System.err.println("Could not download resource " + resourceID);
+      ex.printStackTrace();
       output.delete();
     }
   }
@@ -133,6 +229,13 @@ public class SpigotPluginDownloader extends Tool {
   @Override
   public String getDescription() {
     return "Downloads every spigot plugin";
+  }
+
+  private String downloadToString(String urlString) throws IOException {
+    URL url = new URL(urlString);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.addRequestProperty("User-Agent", "Optic_Fusion1 AntimalwareToolkit");
+    return IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
   }
 
 }

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/NumberConversions.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/NumberConversions.java
@@ -9,73 +9,85 @@ public final class NumberConversions {
   }
 
   public static int toInt(@Nullable final Object object) {
+    if (object == null) {
+      return 0;
+    }
     if (object instanceof Number) {
       return ((Number) object).intValue();
     }
     try {
       return Integer.parseInt(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0;
   }
 
   public static float toFloat(@Nullable final Object object) {
+    if (object == null) {
+      return 0.0f;
+    }
     if (object instanceof Number) {
       return ((Number) object).floatValue();
     }
     try {
       return Float.parseFloat(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0.0f;
   }
 
   public static double toDouble(@Nullable final Object object) {
+    if (object == null) {
+      return 0.0;
+    }
     if (object instanceof Number) {
       return ((Number) object).doubleValue();
     }
     try {
       return Double.parseDouble(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0.0;
   }
 
   public static long toLong(@Nullable final Object object) {
+    if (object == null) {
+      return 0L;
+    }
     if (object instanceof Number) {
       return ((Number) object).longValue();
     }
     try {
       return Long.parseLong(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0L;
   }
 
   public static short toShort(@Nullable final Object object) {
+    if (object == null) {
+      return 0;
+    }
     if (object instanceof Number) {
       return ((Number) object).shortValue();
     }
     try {
       return Short.parseShort(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0;
   }
 
   public static byte toByte(@Nullable final Object object) {
+    if (object == null) {
+      return 0;
+    }
     if (object instanceof Number) {
       return ((Number) object).byteValue();
     }
     try {
       return Byte.parseByte(object.toString());
-    } catch (NumberFormatException ex) {
-    } catch (NullPointerException ex2) {
+    } catch (NumberFormatException ignored) {
     }
     return 0;
   }

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/ParseException.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/ParseException.java
@@ -1,4 +1,4 @@
-package optic_fusion1.faith.util.shellparser;
+package optic_fusion1.antimalwaretoolkit.util.shellparser;
 
 public class ParseException extends Exception {
 

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/ShellParser.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/ShellParser.java
@@ -1,8 +1,8 @@
-package optic_fusion1.faith.util.shellparser;
+package optic_fusion1.antimalwaretoolkit.util.shellparser;
 
 import java.util.ArrayList;
 import java.util.List;
-import optic_fusion1.faith.util.shellparser.states.StartState;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.states.StartState;
 
 public final class ShellParser {
 
@@ -17,6 +17,7 @@ public final class ShellParser {
     try {
       return parseString(string);
     } catch (ParseException e) {
+      e.printStackTrace();
       return null;
     }
   }

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/EscapeState.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/EscapeState.java
@@ -1,13 +1,13 @@
-package optic_fusion1.faith.util.shellparser.states;
+package optic_fusion1.antimalwaretoolkit.util.shellparser.states;
 
 import java.util.List;
-import optic_fusion1.faith.util.shellparser.ParseException;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ParseException;
 
 public class EscapeState extends State {
 
   @Override
   public List<String> parse(final String parsing, final String accumulator, final List<String> parsed, final State referrer) throws ParseException {
-    if (parsing.length() == 0) {
+    if (parsing.isEmpty()) {
       throw new ParseException("Unexpected end of string after escape character");
     }
     return referrer.parse(parsing.substring(1), accumulator + (char) parsing.getBytes()[0], parsed, this);

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/QuoteState.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/QuoteState.java
@@ -1,7 +1,7 @@
-package optic_fusion1.faith.util.shellparser.states;
+package optic_fusion1.antimalwaretoolkit.util.shellparser.states;
 
 import java.util.List;
-import optic_fusion1.faith.util.shellparser.ParseException;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ParseException;
 
 public class QuoteState extends State {
 
@@ -13,7 +13,7 @@ public class QuoteState extends State {
 
   @Override
   public List<String> parse(final String parsing, final String accumulator, final List<String> parsed, final State referrer) throws ParseException {
-    if (parsing.length() == 0) {
+    if (parsing.isEmpty()) {
       throw new ParseException("Mismatched quote character: " + this.quote);
     }
     final char c = (char) parsing.getBytes()[0];

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/SingleQuoteState.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/SingleQuoteState.java
@@ -1,4 +1,4 @@
-package optic_fusion1.faith.util.shellparser.states;
+package optic_fusion1.antimalwaretoolkit.util.shellparser.states;
 
 import java.util.List;
 

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/StartState.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/StartState.java
@@ -1,14 +1,14 @@
-package optic_fusion1.faith.util.shellparser.states;
+package optic_fusion1.antimalwaretoolkit.util.shellparser.states;
 
 import java.util.List;
-import optic_fusion1.faith.util.shellparser.ParseException;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ParseException;
 
 public class StartState extends State {
 
   @Override
   public List<String> parse(final String parsing, final String accumulator, final List<String> parsed, final State referrer) throws ParseException {
-    if (parsing.length() == 0) {
-      if (accumulator.length() > 0) {
+    if (parsing.isEmpty()) {
+      if (!accumulator.isEmpty()) {
         parsed.add(accumulator);
       }
       return parsed;
@@ -16,7 +16,7 @@ public class StartState extends State {
     final char c = (char) parsing.getBytes()[0];
     switch (c) {
       case ' ': {
-        if (accumulator.length() > 0) {
+        if (!accumulator.isEmpty()) {
           parsed.add(accumulator);
         }
         return new StartState().parse(parsing.substring(1), "", parsed, this);

--- a/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/State.java
+++ b/src/main/java/optic_fusion1/antimalwaretoolkit/util/shellparser/states/State.java
@@ -1,7 +1,7 @@
-package optic_fusion1.faith.util.shellparser.states;
+package optic_fusion1.antimalwaretoolkit.util.shellparser.states;
 
 import java.util.List;
-import optic_fusion1.faith.util.shellparser.ParseException;
+import optic_fusion1.antimalwaretoolkit.util.shellparser.ParseException;
 
 public abstract class State {
 


### PR DESCRIPTION
SpigotPluginDownloader is now multithreaded and got a maximum page option + misc changes and package fixes

SpigotPluginDownloader:
- Now saves last update time and skips not updated plugins.
- It moves old update jars to the old folder, when a new update for the plugin is found.
- Fixes skript file skipping.
- Added time logging.
- Does not use a specific spiget api server anymore, it can now follow 307 redirects.

Now has ? command to list all tools and stop command to stop.


### Regression:
Due to the multithreading, it does not stop automatically anymore when the end is reached. Therefore yo ucan now specify the maximum amount of pages to downloads, defaulting to 10.