### PR TITLE
Followup: Make Bukkit downloader multithreaded

### DIFF
--- a/AntiMalwareToolKit/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/BukkitPluginDownloader.java
+++ b/AntiMalwareToolKit/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/BukkitPluginDownloader.java
@@ -32,8 +32,14 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 import static optic_fusion1.antimalwaretoolkit.Main.LOGGER;
 import optic_fusion1.antimalwaretoolkit.tool.Tool;
@@ -59,9 +65,78 @@ public class BukkitPluginDownloader extends Tool {
             LOGGER.info("                       4: Popularity");
             LOGGER.info("                       5: Total downloads");
             LOGGER.info("   dir PATH         Sets the download folder (default data/plugins/bukkit)");
+            LOGGER.info("   threads NUMBER   Sets the download folder (default data/plugins/bukkit)");
             return;
         }
 
+        // Parse options
+        final Options options = Options.parse(args);
+        if (options.threads <= 0) {
+            LOGGER.warn("At least one thread is needed");
+            return;
+        }
+
+        LOGGER.info("Running Bukkit downloader with " + options.threads + " threads");
+
+        // Create thread pool and web clients
+        // Each thread has its own web client
+        final Map<Long, WebClient> webClientMap = new HashMap<>();
+        final ExecutorService threadPool = Executors.newFixedThreadPool(options.threads, runnable -> {
+            final Thread thread = new Thread(runnable);
+
+            final WebClient webClient = this.constructWebClient();
+            webClientMap.put(thread.getId(), webClient);
+
+            return thread;
+        });
+        threadPool.submit(() -> LOGGER.info("Thread pool is ready"));
+
+        final int maxPage = options.toPage == -1 ? this.establishPages(webClientMap.values().iterator().next()) : options.toPage;
+        if (maxPage <= options.fromPage) {
+            LOGGER.warn("Invalid end page");
+            return;
+        }
+
+        // Create download dir
+        new File(options.downloadFolder).mkdirs();
+
+        final AtomicBoolean isDone = new AtomicBoolean(false);
+        for (int i = options.fromPage; i <= maxPage; i++) {
+            final int finalI = i;
+            // Submit page download
+            threadPool.submit(() -> {
+                try {
+                    this.downloadPage(webClientMap.get(Thread.currentThread().getId()), options, finalI);
+                } catch (final IOException e) {
+                    LOGGER.error("Failed to download page", e);
+                }
+
+                if (finalI == maxPage) {
+                    // Last page was downloaded, we are done
+                    isDone.set(true);
+                }
+            });
+        }
+
+        // Block while the downloader does its thing
+        while (!isDone.get()) {
+        }
+
+        // Clean up
+        LOGGER.info("Cleaning up...");
+        webClientMap.forEach((threadId, webClient) -> {
+            LOGGER.info("Disposing web client for thread #" + threadId);
+            webClient.close();
+        });
+        webClientMap.clear();
+    }
+
+    /**
+     * Creates a new webclient
+     *
+     * @return a brand new web client
+     */
+    private WebClient constructWebClient() {
         // Construct web client
         final WebClient webClient = new WebClient(BrowserVersion.FIREFOX);
         webClient.getOptions().setJavaScriptEnabled(true);
@@ -74,29 +149,8 @@ public class BukkitPluginDownloader extends Tool {
         webClient.getOptions().setPrintContentOnFailingStatusCode(false);
         webClient.getOptions().setUseInsecureSSL(true);
         webClient.getOptions().setPopupBlockerEnabled(false);
-        java.util.logging.Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF);
-
-        // Parse options
-        final Options options = Options.parse(args);
-        final int maxPage = options.toPage == -1 ? this.establishPages(webClient) : options.toPage;
-        if (maxPage <= options.fromPage) {
-            LOGGER.warn("Invalid end page");
-            return;
-        }
-
-        // Create download dir
-        new File(options.downloadFolder).mkdirs();
-
-        for (int i = options.fromPage; i <= maxPage; i++) {
-            try {
-                this.downloadPage(webClient, options, i);
-            } catch (final IOException e) {
-                LOGGER.error("Failed to download page", e);
-            }
-        }
-
-        LOGGER.info("Cleaning up...");
-        webClient.close();
+        Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF);
+        return webClient;
     }
 
     /**
@@ -216,7 +270,7 @@ public class BukkitPluginDownloader extends Tool {
                     final String downloadUrl = jsonObject.get("downloadUrl").getAsString();
                     final String fileName = jsonObject.get("fileName").getAsString();
 
-                    System.out.println("Downloading release '" + fileName + "' from resource '" + resourceInfo.name + "'");
+                    LOGGER.info("Downloading release '" + fileName + "' from resource '" + resourceInfo.name + "'");
                     this.downloadRelease(downloadUrl, fileName, options);
                 });
     }
@@ -296,6 +350,11 @@ public class BukkitPluginDownloader extends Tool {
         public String downloadFolder = "./data/plugins/bukkit";
 
         /**
+         * Amount of threads
+         */
+        public int threads = 4;
+
+        /**
          * Attempts to parse the arguments
          *
          * @param args The arguments
@@ -319,6 +378,8 @@ public class BukkitPluginDownloader extends Tool {
                         case "sort" -> options.sort = Integer.parseInt(args.get(i + 1));
                         // Downloads folder
                         case "dir" -> options.downloadFolder = args.get(i + 1);
+                        // Amount of threads
+                        case "threads" -> options.threads = Integer.parseInt(args.get(i + 1));
                     }
                 }
             }

--- a/AntiMalwareToolKit/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/BukkitPluginDownloader.java
+++ b/AntiMalwareToolKit/src/main/java/optic_fusion1/antimalwaretoolkit/tool/impl/BukkitPluginDownloader.java
@@ -65,7 +65,8 @@ public class BukkitPluginDownloader extends Tool {
             LOGGER.info("                       4: Popularity");
             LOGGER.info("                       5: Total downloads");
             LOGGER.info("   dir PATH         Sets the download folder (default data/plugins/bukkit)");
-            LOGGER.info("   threads NUMBER   Sets the download folder (default data/plugins/bukkit)");
+            LOGGER.info("   threads NUMBER   Sets the amount of threads to use (default 4)");
+            LOGGER.info("   multidir BOOL    Sets whether or not each project should be downloaded in a separate directory (default true)");
             return;
         }
 
@@ -102,16 +103,16 @@ public class BukkitPluginDownloader extends Tool {
 
         final AtomicBoolean isDone = new AtomicBoolean(false);
         for (int i = options.fromPage; i <= maxPage; i++) {
-            final int finalI = i;
+            final int pageNumber = i;
             // Submit page download
             threadPool.submit(() -> {
                 try {
-                    this.downloadPage(webClientMap.get(Thread.currentThread().getId()), options, finalI);
+                    this.downloadPage(webClientMap.get(Thread.currentThread().getId()), options, pageNumber);
                 } catch (final IOException e) {
                     LOGGER.error("Failed to download page", e);
                 }
 
-                if (finalI == maxPage) {
+                if (pageNumber == maxPage) {
                     // Last page was downloaded, we are done
                     isDone.set(true);
                 }
@@ -271,19 +272,25 @@ public class BukkitPluginDownloader extends Tool {
                     final String fileName = jsonObject.get("fileName").getAsString();
 
                     LOGGER.info("Downloading release '" + fileName + "' from resource '" + resourceInfo.name + "'");
-                    this.downloadRelease(downloadUrl, fileName, options);
+                    this.downloadRelease(resourceInfo.id, downloadUrl, fileName, options);
                 });
     }
 
     /**
      * Downloads a single release of a resource
      *
+     * @param projectId   The project id
      * @param downloadUrl The download url
      * @param fileName    The name of the file
      * @param options     The parsed options
      */
-    private void downloadRelease(final String downloadUrl, final String fileName, final Options options) {
-        File destination = new File(options.downloadFolder, fileName);
+    private void downloadRelease(final String projectId, final String downloadUrl, final String fileName, final Options options) {
+        final File downloadFolder = options.perProjectDirs
+                ? new File(options.downloadFolder, projectId)
+                : new File(options.downloadFolder);
+        downloadFolder.mkdirs();
+
+        File destination = new File(downloadFolder, fileName);
         if (destination.exists()) {
             // Extract name
             final String namePartOne = fileName.substring(0, fileName.lastIndexOf("."));
@@ -292,7 +299,7 @@ public class BukkitPluginDownloader extends Tool {
 
             // Build new name
             while (destination.exists()) {
-                destination = new File(options.downloadFolder, namePartOne + "_" + (c++) + namePartTwo);
+                destination = new File(downloadFolder, namePartOne + "_" + (c++) + namePartTwo);
             }
         }
 
@@ -355,6 +362,11 @@ public class BukkitPluginDownloader extends Tool {
         public int threads = 4;
 
         /**
+         * whether or not each project should be downloaded in a separate directory
+         */
+        public boolean perProjectDirs = true;
+
+        /**
          * Attempts to parse the arguments
          *
          * @param args The arguments
@@ -380,6 +392,8 @@ public class BukkitPluginDownloader extends Tool {
                         case "dir" -> options.downloadFolder = args.get(i + 1);
                         // Amount of threads
                         case "threads" -> options.threads = Integer.parseInt(args.get(i + 1));
+                        // Per project folders
+                        case "multidir" -> options.perProjectDirs = Boolean.parseBoolean(args.get(i + 1));
                     }
                 }
             }


### PR DESCRIPTION
**Changes**:
- Bukkit downloader is now multithreaded
    - Amount of threads can be configured, default is 4
- Each project will be downloaded in a separate directory to reduce clutter
    - Can be configured, default is true

Resolves #6 